### PR TITLE
gl_verification.yaml: permissions: actions: read

### DIFF
--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -50,6 +50,7 @@ jobs:
     - name: Fetch user project, update caravel configuration
       run: python ./tt/configure.py --clone-all --fetch-gds --update-caravel --sram-support
       env:
+        GITHUB_TOKEN:   ${{ secrets.GITHUB_TOKEN }}
         GH_TOKEN:       ${{ secrets.GH_TOKEN }}
         GH_USERNAME:    ${{ secrets.GH_USERNAME }}
 

--- a/.github/workflows/gl_verification.yaml
+++ b/.github/workflows/gl_verification.yaml
@@ -9,9 +9,6 @@ jobs:
         OPENLANE_ROOT:      /home/runner/openlane
         PDK_ROOT:           /home/runner/pdk
         PDK:                sky130A
-        GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
-        GH_TOKEN:           ${{ secrets.GH_TOKEN }}
-        GH_USERNAME:        ${{ secrets.GH_USERNAME }}
         DESIGNS:            /home/runner/work/tinytapeout-03p5/tinytapeout-03p5
         TARGET_PATH:        /home/runner/work/tinytapeout-03p5/tinytapeout-03p5
         MGMT_AREA_ROOT:     /home/runner/work/tinytapeout-03p5/tinytapeout-03p5/mgmt_core_wrapper
@@ -82,6 +79,10 @@ jobs:
 
     # fetch the repos,
     - name: Fetch user project, update caravel configuration
+      env:
+        GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN:           ${{ secrets.GH_TOKEN }}
+        GH_USERNAME:        ${{ secrets.GH_USERNAME }}
       run: python ./tt/configure.py --test --clone-all --fetch-gds --update-caravel
 
     # generate the tt mux verilog that instantiates all the modules - use the test version

--- a/.github/workflows/gl_verification.yaml
+++ b/.github/workflows/gl_verification.yaml
@@ -9,6 +9,7 @@ jobs:
         OPENLANE_ROOT:      /home/runner/openlane
         PDK_ROOT:           /home/runner/pdk
         PDK:                sky130A
+        GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
         GH_TOKEN:           ${{ secrets.GH_TOKEN }}
         GH_USERNAME:        ${{ secrets.GH_USERNAME }}
         DESIGNS:            /home/runner/work/tinytapeout-03p5/tinytapeout-03p5

--- a/.github/workflows/gl_verification.yaml
+++ b/.github/workflows/gl_verification.yaml
@@ -20,6 +20,11 @@ jobs:
         GCC_PATH:           /home/runner/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14/bin/
         GCC_PREFIX:         riscv64-unknown-elf
 
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+
     # ubuntu
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/verification.yaml
+++ b/.github/workflows/verification.yaml
@@ -7,6 +7,7 @@ jobs:
         OPENLANE_ROOT:      /home/runner/openlane
         PDK_ROOT:           /home/runner/pdk
         PDK:                sky130A
+        GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
         GH_TOKEN:           ${{ secrets.GH_TOKEN }}
         GH_USERNAME:        ${{ secrets.GH_USERNAME }}
         DESIGNS:            /home/runner/work/tinytapeout-03p5/tinytapeout-03p5

--- a/.github/workflows/verification.yaml
+++ b/.github/workflows/verification.yaml
@@ -7,9 +7,6 @@ jobs:
         OPENLANE_ROOT:      /home/runner/openlane
         PDK_ROOT:           /home/runner/pdk
         PDK:                sky130A
-        GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
-        GH_TOKEN:           ${{ secrets.GH_TOKEN }}
-        GH_USERNAME:        ${{ secrets.GH_USERNAME }}
         DESIGNS:            /home/runner/work/tinytapeout-03p5/tinytapeout-03p5
         TARGET_PATH:        /home/runner/work/tinytapeout-03p5/tinytapeout-03p5
         MGMT_AREA_ROOT:     /home/runner/work/tinytapeout-03p5/tinytapeout-03p5/mgmt_core_wrapper
@@ -70,6 +67,10 @@ jobs:
 
     # fetch the repos - test mode
     - name: fetch all
+      env:
+        GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN:           ${{ secrets.GH_TOKEN }}
+        GH_USERNAME:        ${{ secrets.GH_USERNAME }}
       run: python ./tt/configure.py --clone-all --fetch-gds --debug --test
 
     # install projects


### PR DESCRIPTION
Does this fix the GHA permissions issue concerning this workflow (see link into git_utils.py), by requesting `actions:read` scope to be included into `${{ secrets.GITHUB_TOKEN }}`.

The permissions `contents:read` and `packages:read` are baseline defaults, when no `permissions` section exists in the workflow.

---

The 'actions:read' is added due to this comment here:
  https://github.com/TinyTapeout/tt-support-tools/blob/tt03/git_utils.py#L150

```
  permissions:
    actions: read
    contents: read
    packages: read
```

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-the-default-github_token-permissions

This section in link above confirms the 'contents:read' and 'packages:read' are a default baseline permissions.

Related reading:
  https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
  https://docs.github.com/en/actions/security-guides/automatic-token-authentication